### PR TITLE
Add minimal backend server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+backend/node_modules

--- a/README.md
+++ b/README.md
@@ -236,3 +236,5 @@ Set up monitoring and logging
 
 Contributing
 This is the backend implementation for the MentorLink platform. The frontend UI components are being built with v0.dev based on the design specifications in the UI roadmap.
+
+For backend setup instructions see `backend/README.md`.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL=postgresql://username:password@localhost:5432/mentorlink
+JWT_SECRET=your-secret-key
+PORT=5000

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,31 @@
+# MentorLink Backend
+
+This directory contains a minimal Express + Prisma backend for the MentorLink platform described in the project README.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and update the values.
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Generate Prisma client and run migrations (requires internet access):
+   ```bash
+   npx prisma generate
+   npx prisma migrate dev --name init
+   ```
+4. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+The server will start on `PORT` defined in the `.env` file (default `5000`).
+
+## Provided Endpoints
+
+- `POST /api/auth/register` – create a new user
+- `POST /api/auth/login` – user login
+- `GET /api/mentors` – list mentors
+- `POST /api/sessions` – create a session booking
+
+These endpoints use the database schema defined in `prisma/schema.prisma`.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "dev": "nodemon src/server.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@prisma/client": "^6.12.0",
+    "@types/morgan": "^1.9.10",
+    "bcryptjs": "^3.0.2",
+    "cors": "^2.8.5",
+    "dotenv": "^17.2.0",
+    "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.2",
+    "morgan": "^1.10.1"
+  },
+  "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
+    "@types/cors": "^2.8.19",
+    "@types/express": "^5.0.3",
+    "@types/jsonwebtoken": "^9.0.10",
+    "@types/node": "^24.0.14",
+    "nodemon": "^3.1.10",
+    "prisma": "^6.12.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.8.3"
+  }
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,117 @@
+// Prisma schema for MentorLink backend
+// Adjust database provider via env var DATABASE_URL
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id             Int       @id @default(autoincrement())
+  email          String    @unique
+  passwordHash   String
+  userType       String
+  firstName      String
+  lastName       String
+  profilePhotoUrl String?  @map("profile_photo_url")
+  createdAt      DateTime  @default(now()) @map("created_at")
+  updatedAt      DateTime  @updatedAt @map("updated_at")
+
+  mentorProfile  MentorProfile?
+  menteeProfile  MenteeProfile?
+  categories     UserCategory[]
+  sentMessages   Message[]   @relation("sent")
+  sessionsAsMentor Session[]  @relation("mentor")
+  sessionsAsMentee Session[]  @relation("mentee")
+}
+
+model MentorProfile {
+  userId          Int      @id @map("user_id")
+  company         String?
+  jobTitle        String?  @map("job_title")
+  yearsExperience Int?     @map("years_experience")
+  hourlyRate      Int?     @map("hourly_rate")
+  bio             String?
+  skills          String?
+  availabilitySchedule String? @map("availability_schedule")
+
+  user            User     @relation(fields: [userId], references: [id])
+}
+
+model MenteeProfile {
+  userId    Int    @id @map("user_id")
+  university String?
+  degree     String?
+  yearOfStudy Int?   @map("year_of_study")
+  goals       String?
+  bio         String?
+
+  user        User  @relation(fields: [userId], references: [id])
+}
+
+model Category {
+  id          Int     @id @default(autoincrement())
+  name        String  @unique
+  description String?
+  iconUrl     String? @map("icon_url")
+  users       UserCategory[]
+}
+
+model UserCategory {
+  userId     Int  @map("user_id")
+  categoryId Int  @map("category_id")
+  isPrimary  Boolean @default(false) @map("is_primary")
+
+  user       User     @relation(fields: [userId], references: [id])
+  category   Category @relation(fields: [categoryId], references: [id])
+
+  @@id([userId, categoryId])
+}
+
+model Session {
+  id             Int      @id @default(autoincrement())
+  mentorId       Int      @map("mentor_id")
+  menteeId       Int      @map("mentee_id")
+  scheduledAt    DateTime @map("scheduled_at")
+  durationMinutes Int     @map("duration_minutes")
+  status         String
+  totalAmount    Int?     @map("total_amount")
+  sessionGoals   String?  @map("session_goals")
+  notes          String?
+  createdAt      DateTime @default(now()) @map("created_at")
+
+  mentor         User     @relation("mentor", fields: [mentorId], references: [id])
+  mentee         User     @relation("mentee", fields: [menteeId], references: [id])
+  messages       Message[]
+  payment        Payment?
+}
+
+model Message {
+  id        Int      @id @default(autoincrement())
+  sessionId Int      @map("session_id")
+  senderId  Int      @map("sender_id")
+  content   String
+  timestamp DateTime @default(now())
+  isRead    Boolean  @default(false) @map("is_read")
+
+  session   Session  @relation(fields: [sessionId], references: [id])
+  sender    User     @relation("sent", fields: [senderId], references: [id])
+}
+
+model Payment {
+  id            Int      @id @default(autoincrement())
+  sessionId     Int      @map("session_id")
+  amount        Int
+  currency      String
+  paymentMethod String   @map("payment_method")
+  status        String
+  transactionId String?  @map("transaction_id")
+  createdAt     DateTime @default(now()) @map("created_at")
+
+  session       Session  @relation(fields: [sessionId], references: [id])
+}
+

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,70 @@
+import express from 'express';
+import cors from 'cors';
+import morgan from 'morgan';
+import dotenv from 'dotenv';
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+
+dotenv.config();
+
+const prisma = new PrismaClient();
+const app = express();
+app.use(cors());
+app.use(express.json());
+app.use(morgan('dev'));
+
+const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+
+function generateToken(userId: number) {
+  return jwt.sign({ userId }, JWT_SECRET, { expiresIn: '24h' });
+}
+
+// Register
+app.post('/api/auth/register', async (req, res) => {
+  const { email, password, firstName, lastName, userType } = req.body;
+  if (!email || !password) return res.status(400).json({ message: 'Missing email or password' });
+  const existing = await prisma.user.findUnique({ where: { email } });
+  if (existing) return res.status(400).json({ message: 'Email already exists' });
+  const passwordHash = await bcrypt.hash(password, 10);
+  const user = await prisma.user.create({ data: { email, passwordHash, firstName, lastName, userType } });
+  const token = generateToken(user.id);
+  res.json({ token, user });
+});
+
+// Login
+app.post('/api/auth/login', async (req, res) => {
+  const { email, password } = req.body;
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) return res.status(400).json({ message: 'Invalid credentials' });
+  const valid = await bcrypt.compare(password, user.passwordHash);
+  if (!valid) return res.status(400).json({ message: 'Invalid credentials' });
+  const token = generateToken(user.id);
+  res.json({ token, user });
+});
+
+// Get mentors (basic)
+app.get('/api/mentors', async (_req, res) => {
+  const mentors = await prisma.user.findMany({ where: { userType: 'mentor' }, include: { mentorProfile: true } });
+  res.json(mentors);
+});
+
+// Create session
+app.post('/api/sessions', async (req, res) => {
+  const { mentorId, menteeId, scheduledAt } = req.body;
+  const session = await prisma.session.create({
+    data: {
+      mentorId,
+      menteeId,
+      scheduledAt: new Date(scheduledAt),
+      durationMinutes: 60,
+      status: 'confirmed'
+    }
+  });
+  res.json(session);
+});
+
+const PORT = process.env.PORT || 5000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add Express + Prisma backend skeleton
- document backend setup and endpoints
- add DB schema with Prisma
- update root README with link to backend instructions
- ignore backend/node_modules

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_687a7d2fecdc832cbe57059632928c25